### PR TITLE
docs: update example output to match current fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,64 +20,72 @@ A Go program to display certificate chains and validate their order in the same 
 
 ### Example Output (no days)
 
-	Subject: *.chrisshort.net
-	Issuer: R3
-	Valid from: 2023-04-25 02:30:44 +0000 UTC
-	Valid until: 2023-07-24 02:30:43 +0000 UTC
-	Serial number: 403588798235445259445834570997555816122123
-	DNS Names: [*.chrisshort.net chrisshort.net]
+	Subject: chrisshort.net
+	Issuer: E7
+	Valid from: 2026-05-25 00:29:00 +0000 UTC
+	Valid until: 2026-08-23 00:28:59 +0000 UTC
+	Serial number: 455967643380891922849939626027783376065774
+	DNS Names: [*.chrisshort.me *.chrisshort.us chrisshort.me chrisshort.net chrisshort.us www.chrisshort.net]
 	IP Addresses: []
-	Signature algorithm: SHA256-RSA
+	Signature algorithm: ECDSA-SHA384
+	Cipher in use: TLS_AES_128_GCM_SHA256
+	KeyUsage:
+	- Digital Signature
+	Fingerprint (SHA-256): 81cd2cce6caf805ec597523569b7389ffef006ac49e2dc83e43a5e1caa93ed2e
+	HSTS Header: max-age=63072000; includeSubDomains; preload
 	-----
-	Subject: R3
+	Subject: E7
 	Issuer: ISRG Root X1
-	Valid from: 2020-09-04 00:00:00 +0000 UTC
-	Valid until: 2025-09-15 16:00:00 +0000 UTC
-	Serial number: 192961496339968674994309121183282847578
+	Valid from: 2024-03-13 00:00:00 +0000 UTC
+	Valid until: 2027-03-12 23:59:59 +0000 UTC
+	Serial number: 226581164312556911225609404641709439649
 	DNS Names: []
 	IP Addresses: []
 	Signature algorithm: SHA256-RSA
-	-----
-	Subject: ISRG Root X1
-	Issuer: DST Root CA X3
-	Valid from: 2021-01-20 19:14:03 +0000 UTC
-	Valid until: 2024-09-30 18:14:03 +0000 UTC
-	Serial number: 85078200265644417569109389142156118711
-	DNS Names: []
-	IP Addresses: []
-	Signature algorithm: SHA256-RSA
+	Cipher in use: TLS_AES_128_GCM_SHA256
+	KeyUsage:
+	- Digital Signature
+	- Certificate Signing
+	- CRL Signing
+	Fingerprint (SHA-256): aeb1fd7410e83bc96f5da3c6a7c2c1bb836d1fa5cb86e708515890e428a8770b
+	HSTS Header: max-age=63072000; includeSubDomains; preload
 	-----
 	Certificate chain is valid and in the correct order.
 
 ### Example Output with Days
 
-	Subject: *.chrisshort.net
-	Issuer: R3
-	Valid from: 2023-04-25 02:30:44 +0000 UTC
-	Valid until: 2023-07-24 02:30:43 +0000 UTC (66 days left)
-	Serial number: 403588798235445259445834570997555816122123
-	DNS Names: [*.chrisshort.net chrisshort.net]
+	Subject: chrisshort.net
+	Issuer: E7
+	Valid from: 2026-05-25 00:29:00 +0000 UTC
+	Valid until: 2026-08-23 00:28:59 +0000 UTC (57 days left)
+	Serial number: 455967643380891922849939626027783376065774
+	DNS Names: [*.chrisshort.me *.chrisshort.us chrisshort.me chrisshort.net chrisshort.us www.chrisshort.net]
 	IP Addresses: []
-	Signature algorithm: SHA256-RSA
+	Signature algorithm: ECDSA-SHA384
+	Cipher in use: TLS_AES_128_GCM_SHA256
+	KeyUsage:
+	- Digital Signature
+	Fingerprint (SHA-256): 81cd2cce6caf805ec597523569b7389ffef006ac49e2dc83e43a5e1caa93ed2e
+	HSTS Header: max-age=63072000; includeSubDomains; preload
 	-----
-	Subject: R3
-	Issuer: ISRG Root X1
-	Valid from: 2020-09-04 00:00:00 +0000 UTC
-	Valid until: 2025-09-15 16:00:00 +0000 UTC
-	Serial number: 192961496339968674994309121183282847578
-	DNS Names: []
-	IP Addresses: []
-	Signature algorithm: SHA256-RSA
-	-----
-	Subject: ISRG Root X1
-	Issuer: DST Root CA X3
-	Valid from: 2021-01-20 19:14:03 +0000 UTC
-	Valid until: 2024-09-30 18:14:03 +0000 UTC
-	Serial number: 85078200265644417569109389142156118711
-	DNS Names: []
-	IP Addresses: []
-	Signature algorithm: SHA256-RSA
-	-----
+	Certificate chain is valid and in the correct order.
+
+### Example Output with Redirects
+
+When a URL redirects, each hop in the chain is reported separately:
+
+	=== Hop 1: https://commandlineheroes.com → https://www.redhat.com/en/command-line-heroes (HTTP 301) ===
+
+	Subject: commandlineheroes.com
+	Issuer: YE1
+	...
+	Certificate chain is valid and in the correct order.
+
+	=== Hop 2: https://www.redhat.com/en/command-line-heroes (HTTP 200) ===
+
+	Subject: www.redhat.com
+	Issuer: DigiCert EV RSA CA G2
+	...
 	Certificate chain is valid and in the correct order.
 
 ## About


### PR DESCRIPTION
## Summary

- Updates example output in README to include all fields the tool now emits: Cipher in use, KeyUsage, Fingerprint (SHA-256), HSTS Header
- Adds a new redirect example section showing the per-hop output format

> **Note:** depends on #24 (redirect chain handling) landing first — the redirect example and updated fields come from that change.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)