### PR TITLE
ci: add goreleaser config with changelog generation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,37 @@
+version: 2
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch


### PR DESCRIPTION
## Summary

- Adds `.goreleaser.yaml` to replace goreleaser's implicit defaults
- Defines explicit build targets: linux/darwin/windows, amd64/arm64
- Sets archive format (tar.gz, zip for Windows)
- Enables changelog generation sorted ascending, filtering out merge commits, docs, tests, and chores

## Test plan

- [ ] Merge and confirm next release generates a changelog in the GitHub release notes

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)