### PR TITLE
feat: add Homebrew tap via Goreleaser

### DIFF
--- a/.github/workflows/build_binaries.yaml
+++ b/.github/workflows/build_binaries.yaml
@@ -54,3 +54,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,20 @@ archives:
         formats:
           - zip
 
+brews:
+  - name: chkcerts
+    repository:
+      owner: chris-short
+      name: homebrew-chkcerts
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/chris-short/chkcerts
+    description: Display and validate TLS certificate chains from the command line
+    license: MIT
+    test: |
+      system "#{bin}/chkcerts", "https://github.com"
+    install: |
+      bin.install "chkcerts"
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary

- Creates [chris-short/homebrew-chkcerts](https://github.com/chris-short/homebrew-chkcerts) tap repo (already done)
- Adds `brews:` block to `.goreleaser.yaml` so each release automatically pushes an updated formula to the tap
- Passes `HOMEBREW_TAP_GITHUB_TOKEN` into the Goreleaser step in the release workflow

Once merged, users can install with:

```sh
brew tap chris-short/chkcerts
brew install chkcerts
```

## One manual step required before merging

Goreleaser needs write access to the tap repo, which `GITHUB_TOKEN` doesn't cover (it's scoped to this repo only). You need to create a PAT and add it as a secret:

1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens**
2. Create a token scoped to the `chris-short/homebrew-chkcerts` repo with **Contents: Read and Write** permission
3. Go to **this repo → Settings → Secrets and variables → Actions**
4. Add a secret named `HOMEBREW_TAP_GITHUB_TOKEN` with that token value

## Test plan

- [ ] Add `HOMEBREW_TAP_GITHUB_TOKEN` secret (see above)
- [ ] Merge this PR — the next push to main will run a release and push `Formula/chkcerts.rb` to the tap repo
- [ ] `brew tap chris-short/chkcerts && brew install chkcerts` works on a Mac

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)